### PR TITLE
Downgrade PHP requirement to PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=8.3",
+    "php": ">=8.0",
     "ext-curl": "*",
     "ext-json": "*",
     "simplito/elliptic-php": "^1.0",

--- a/src/FAIR/DID/Crypto/CanonicalMapObject.php
+++ b/src/FAIR/DID/Crypto/CanonicalMapObject.php
@@ -32,7 +32,7 @@ use IteratorAggregate;
  */
 class CanonicalMapObject extends AbstractCBORObject implements \Countable, IteratorAggregate, Normalizable, ArrayAccess
 {
-    private const int MAJOR_TYPE = self::MAJOR_TYPE_MAP;
+    private const MAJOR_TYPE = self::MAJOR_TYPE_MAP;
 
     /**
      * The map data.

--- a/src/FAIR/DID/Crypto/DidCodec.php
+++ b/src/FAIR/DID/Crypto/DidCodec.php
@@ -26,12 +26,12 @@ class DidCodec
     /**
      * Multicodec prefix for secp256k1 public key (0xe7)
      */
-    public const string MULTICODEC_SECP256K1_PUB = "\xe7\x01";
+    public const MULTICODEC_SECP256K1_PUB = "\xe7\x01";
 
     /**
      * Multicodec prefix for Ed25519 public key (0xed)
      */
-    public const string MULTICODEC_ED25519_PUB = "\xed\x01";
+    public const MULTICODEC_ED25519_PUB = "\xed\x01";
 
     /**
      * Convert a public key to multibase base58btc format

--- a/src/FAIR/DID/Keys/Key.php
+++ b/src/FAIR/DID/Keys/Key.php
@@ -22,47 +22,47 @@ interface Key
     /**
      * Curve constant for secp256k1.
      */
-    public const string CURVE_K256 = 'secp256k1';
+    public const CURVE_K256 = 'secp256k1';
 
     /**
      * Curve constant for P-256.
      */
-    public const string CURVE_P256 = 'p256';
+    public const CURVE_P256 = 'p256';
 
     /**
      * Curve constant for Ed25519.
      */
-    public const string CURVE_ED25519 = 'ed25519';
+    public const CURVE_ED25519 = 'ed25519';
 
     /**
      * Multicodec prefix for secp256k1 public key.
      */
-    public const string PREFIX_K256_PUB = "\xe7\x01";
+    public const PREFIX_K256_PUB = "\xe7\x01";
 
     /**
      * Multicodec prefix for secp256k1 private key.
      */
-    public const string PREFIX_K256_PRIV = "\x81\x26";
+    public const PREFIX_K256_PRIV = "\x81\x26";
 
     /**
      * Multicodec prefix for P-256 public key.
      */
-    public const string PREFIX_P256_PUB = "\x80\x24";
+    public const PREFIX_P256_PUB = "\x80\x24";
 
     /**
      * Multicodec prefix for P-256 private key.
      */
-    public const string PREFIX_P256_PRIV = "\x06\x26";
+    public const PREFIX_P256_PRIV = "\x06\x26";
 
     /**
      * Multicodec prefix for Ed25519 public key.
      */
-    public const string PREFIX_ED25519_PUB = "\xed\x01";
+    public const PREFIX_ED25519_PUB = "\xed\x01";
 
     /**
      * Multicodec prefix for Ed25519 private key.
      */
-    public const string PREFIX_ED25519_PRIV = "\x80\x26";
+    public const PREFIX_ED25519_PRIV = "\x80\x26";
 
     /**
      * Does this key represent a private key?


### PR DESCRIPTION
Downgrading the requirement to PHP 8.0 allows to incorporate this library with other libraries like https://github.com/TYPO3/tailor